### PR TITLE
Update README to include dropping migrations table

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,9 @@ systemctl status postgresql
 
 psql 'user=sensu password=P@ssw0rd!'
 
-delete from events;
+drop table events;
+
+drop table migration_version;
 
 VACUUM FULL;
 


### PR DESCRIPTION
Includes instructions to drop the migrations table when cleaning up the database.