### PR TITLE
Add agent base name flag to loadit scripts, disable prometheus

### DIFF
--- a/tests/3-backends-14k-agents-4-subs/loadit1.sh
+++ b/tests/3-backends-14k-agents-4-subs/loadit1.sh
@@ -5,4 +5,6 @@
 -count 3500 \
 -keepalive-interval 60 \
 -keepalive-timeout 360 \
--pprof-port 6060
+-pprof-port 6060 \
+-prom "" \
+-base-entity-name "loadit-1-agent"

--- a/tests/3-backends-14k-agents-4-subs/loadit2.sh
+++ b/tests/3-backends-14k-agents-4-subs/loadit2.sh
@@ -5,4 +5,6 @@
 -count 3500 \
 -keepalive-interval 60 \
 -keepalive-timeout 360 \
--pprof-port 6061
+-pprof-port 6061 \
+-prom "" \
+-base-entity-name "loadit-2-agent"

--- a/tests/3-backends-14k-agents-4-subs/loadit3.sh
+++ b/tests/3-backends-14k-agents-4-subs/loadit3.sh
@@ -5,4 +5,6 @@
 -count 3500 \
 -keepalive-interval 60 \
 -keepalive-timeout 360 \
--pprof-port 6062
+-pprof-port 6062 \
+-prom "" \
+-base-entity-name "loadit-3-agent"

--- a/tests/3-backends-14k-agents-4-subs/loadit4.sh
+++ b/tests/3-backends-14k-agents-4-subs/loadit4.sh
@@ -5,4 +5,6 @@
 -count 3500 \
 -keepalive-interval 60 \
 -keepalive-timeout 360 \
--pprof-port 6063
+-pprof-port 6063 \
+-prom "" \
+-base-entity-name "loadit-4-agent"

--- a/tests/3-backends-20k-agents-4-subs-pg/loadit1.sh
+++ b/tests/3-backends-20k-agents-4-subs-pg/loadit1.sh
@@ -5,4 +5,6 @@
 -count 5000 \
 -keepalive-interval 60 \
 -keepalive-timeout 360 \
--pprof-port 6060
+-pprof-port 6060 \
+-prom "" \
+-base-entity-name "loadit-1-agent"

--- a/tests/3-backends-20k-agents-4-subs-pg/loadit2.sh
+++ b/tests/3-backends-20k-agents-4-subs-pg/loadit2.sh
@@ -5,4 +5,6 @@
 -count 5000 \
 -keepalive-interval 60 \
 -keepalive-timeout 360 \
--pprof-port 6061
+-pprof-port 6061 \
+-prom "" \
+-base-entity-name "loadit-2-agent"

--- a/tests/3-backends-20k-agents-4-subs-pg/loadit3.sh
+++ b/tests/3-backends-20k-agents-4-subs-pg/loadit3.sh
@@ -5,4 +5,6 @@
 -count 5000 \
 -keepalive-interval 60 \
 -keepalive-timeout 360 \
--pprof-port 6062
+-pprof-port 6062 \
+-prom "" \
+-base-entity-name "loadit-3-agent"

--- a/tests/3-backends-20k-agents-4-subs-pg/loadit4.sh
+++ b/tests/3-backends-20k-agents-4-subs-pg/loadit4.sh
@@ -5,4 +5,6 @@
 -count 5000 \
 -keepalive-interval 60 \
 -keepalive-timeout 360 \
--pprof-port 6063
+-pprof-port 6063 \
+-prom "" \
+-base-entity-name "loadit-4-agent"

--- a/tests/3-backends-40k-agents-4-subs-pg/loadit1.sh
+++ b/tests/3-backends-40k-agents-4-subs-pg/loadit1.sh
@@ -5,4 +5,6 @@
 -count 10000 \
 -keepalive-interval 60 \
 -keepalive-timeout 360 \
--pprof-port 6060
+-pprof-port 6060 \
+-prom "" \
+-base-entity-name "loadit-1-agent"

--- a/tests/3-backends-40k-agents-4-subs-pg/loadit2.sh
+++ b/tests/3-backends-40k-agents-4-subs-pg/loadit2.sh
@@ -5,4 +5,6 @@
 -count 10000 \
 -keepalive-interval 60 \
 -keepalive-timeout 360 \
--pprof-port 6061
+-pprof-port 6061 \
+-prom "" \
+-base-entity-name "loadit-2-agent"

--- a/tests/3-backends-40k-agents-4-subs-pg/loadit3.sh
+++ b/tests/3-backends-40k-agents-4-subs-pg/loadit3.sh
@@ -5,4 +5,6 @@
 -count 10000 \
 -keepalive-interval 60 \
 -keepalive-timeout 360 \
--pprof-port 6062
+-pprof-port 6062 \
+-prom "" \
+-base-entity-name "loadit-3-agent"

--- a/tests/3-backends-40k-agents-4-subs-pg/loadit4.sh
+++ b/tests/3-backends-40k-agents-4-subs-pg/loadit4.sh
@@ -5,4 +5,6 @@
 -count 10000 \
 -keepalive-interval 60 \
 -keepalive-timeout 360 \
--pprof-port 6063
+-pprof-port 6063 \
+-prom "" \
+-base-entity-name "loadit-4-agent"

--- a/tests/3-backends-6k-agents-3-subs/loadit1.sh
+++ b/tests/3-backends-6k-agents-3-subs/loadit1.sh
@@ -5,4 +5,6 @@
 -count 2000 \
 -keepalive-interval 60 \
 -keepalive-timeout 360 \
--pprof-port 6060
+-pprof-port 6060 \
+-prom "" \
+-base-entity-name "loadit-1-agent"

--- a/tests/3-backends-6k-agents-3-subs/loadit2.sh
+++ b/tests/3-backends-6k-agents-3-subs/loadit2.sh
@@ -5,4 +5,6 @@
 -count 2000 \
 -keepalive-interval 60 \
 -keepalive-timeout 360 \
--pprof-port 6061
+-pprof-port 6061 \
+-prom "" \
+-base-entity-name "loadit-2-agent"

--- a/tests/3-backends-6k-agents-3-subs/loadit3.sh
+++ b/tests/3-backends-6k-agents-3-subs/loadit3.sh
@@ -5,4 +5,6 @@
 -count 2000 \
 -keepalive-interval 60 \
 -keepalive-timeout 360 \
--pprof-port 6062
+-pprof-port 6062 \
+-prom "" \
+-base-entity-name "loadit-3-agent"


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

Base names are now required to keep the loadit scripts from using conflicting agent names.