### PR TITLE
Update sensu_performance_metrics.json

### DIFF
--- a/grafana/sensu_performance_metrics.json
+++ b/grafana/sensu_performance_metrics.json
@@ -76,7 +76,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(rate(sensu_go_events_processed{status=\"failure\"}[1m])) by (instance)",
+          "expr": "sum(rate(sensu_go_events_processed{status=\"error\"}[1m])) by (instance)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "",


### PR DESCRIPTION
`failure` is not a status for this metric. It is now `error`
<img width="624" alt="sensu00 sachshaus net8080metrics 2022-03-16 at 9 52 56 AM" src="https://user-images.githubusercontent.com/898627/158605606-968848cd-3a5f-43c0-a665-335d2cc8c90b.png">
